### PR TITLE
Implemented CI process just for releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           NAME=$(jq -r '.name' package.json)-$VERSION
           echo ::set-output name=name::$NAME
           mkdir dist
-          npx vsce package -o ./dist/$NAME.vsix
+          npx vsce package -o $NAME.vsix
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -42,14 +42,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./dist/${{ steps.set-version.outputs.name }}.vsix
+          asset_path: ${{ steps.set-version.outputs.name }}.vsix
           asset_name: ${{ steps.set-version.outputs.name }}.vsix
           asset_content_type: application/zip
       - name: Publish to VSCode Marketplace
         run: |
           [ -n "${{ secrets.VSCE_TOKEN }}" ] && \
-            npx vsce publish --packagePath ./dist/${{ steps.set-version.outputs.name }}.vsix -p ${{ secrets.VSCE_TOKEN }} || true
+            npx vsce publish --packagePath ${{ steps.set-version.outputs.name }}.vsix -p ${{ secrets.VSCE_TOKEN }} || true
       - name: Publish to Open VSX Registry
         run: |
           [ -n "${{ secrets.OVSX_TOKEN }}" ] && \
-            npx ovsx publish --packagePath ./dist/${{ steps.set-version.outputs.name }}.vsix --pat ${{ secrets.OVSX_TOKEN }} || true
+            npx ovsx publish --packagePath ${{ steps.set-version.outputs.name }}.vsix --pat ${{ secrets.OVSX_TOKEN }} || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,55 @@
+name: CI
+on:
+  release:
+    types:
+      - released
+jobs:
+  publish:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+          token: ${{ secrets.TOKEN }}
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Prepare build
+        id: set-version
+        run: |
+          VERSION=${{ github.event.release.tag_name }} && VERSION=${VERSION/v/}
+          NEXT_VERSION=`echo $VERSION | awk -F. '/[0-9]+\./{$NF++;print}' OFS=.`
+          tmp=$(mktemp)
+          git config --global user.name 'ProjectBot'
+          git config --global user.email 'bot@users.noreply.github.com'
+          jq --arg version "${NEXT_VERSION}-SNAPSHOT" '.version = $version' package.json > "$tmp" && mv "$tmp" package.json
+          git add package.json
+          git commit -m 'auto bump version with release'
+          git push
+          jq --arg version "$VERSION" '.version = $version' package.json > "$tmp" && mv "$tmp" package.json
+          NAME=$(jq -r '.name' package.json)-$VERSION
+          echo ::set-output name=name::$NAME
+          mkdir dist
+          npx vsce package -o ./dist/$NAME.vsix
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        if: runner.os == 'Linux'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/${{ steps.set-version.outputs.name }}.vsix
+          asset_name: ${{ steps.set-version.outputs.name }}.vsix
+          asset_content_type: application/zip
+      - name: Publish to VSCode Marketplace
+        run: |
+          [ -n "${{ secrets.VSCE_TOKEN }}" ] && \
+            npx vsce publish --packagePath ./dist/${{ steps.set-version.outputs.name }}.vsix -p ${{ secrets.VSCE_TOKEN }} || true
+      - name: Publish to Open VSX Registry
+        run: |
+          [ -n "${{ secrets.OVSX_TOKEN }}" ] && \
+            npx ovsx publish --packagePath ./dist/${{ steps.set-version.outputs.name }}.vsix --pat ${{ secrets.OVSX_TOKEN }} || true

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,5 @@
+.github/**
 .vscode/**
 .vscode-test/**
 .gitignore
-vsc-extension-quickstart.md
+


### PR DESCRIPTION
Do nothing on pushes, but reacts only for new releases.

Resolves #8 
It has to support releases for drafts as well.

Secrets expected:
TOKEN - GitHub token with admin role, to push the new version after release
VSCE_TOKEN - token for vsce, VSCode Marketplace
OVSX_TOKEN - token for ovsx, open-vsx.org. optional